### PR TITLE
fix: fix link destionation to prevent 404

### DIFF
--- a/index.md
+++ b/index.md
@@ -15,7 +15,7 @@ hero:
       link: /eslint/user-guide/installation
     - theme: alt
       text: Perkakas
-      link: /perkakas
+      link: /perkakas/installation
     - theme: alt
       text: UnoCSS
       link: /unocss-preset/installation


### PR DESCRIPTION
As mention in [this issue](https://github.com/vinicunca/docs/issues/1), currently the perkakas hero button will redirect to 404 page since `/perkakas` doesn't exist.

This PR simply change the string to `/perkakas/installation` 